### PR TITLE
added basic Go wrapper for ImgGui::DockSpaceOverViewpor()

### DIFF
--- a/Dock.go
+++ b/Dock.go
@@ -1,0 +1,8 @@
+package imgui
+
+// #include "wrapper/Dock.h"
+import "C"
+
+func DockSpaceOverViewport() {
+	C.iggDockSpaceOverViewport()
+}

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -15,6 +15,7 @@
 #include "wrapper/Color.cpp"
 #include "wrapper/Context.cpp"
 #include "wrapper/Focus.cpp"
+#include "wrapper/Dock.cpp" 
 #include "wrapper/DragDrop.cpp"
 #include "wrapper/DrawCommand.cpp"
 #include "wrapper/DrawData.cpp"

--- a/wrapper/Dock.cpp
+++ b/wrapper/Dock.cpp
@@ -1,0 +1,8 @@
+#include "ConfiguredImGui.h"
+
+#include "Dock.h"
+
+void iggDockSpaceOverViewport()
+{
+   ImGui::DockSpaceOverViewport(0L, NULL, ImGuiDockNodeFlags_PassthruCentralNode, NULL);
+}

--- a/wrapper/Dock.h
+++ b/wrapper/Dock.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void iggDockSpaceOverViewport();
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Exposed the basic (default args) ImGui::DockSpaceOverViewport() to Go, so I can have docking windows in the main viewport. 
